### PR TITLE
Update README to talk about Linux problems

### DIFF
--- a/README
+++ b/README
@@ -92,7 +92,3 @@ prior to distribution:
 
 On Linux you can install the pyside and pycrytpo python modules provided by
 your Linux distribution and create a virtualenv with `--system-site-packages`.
-
-If you have problems running in U2F+CCID mode you might have an older version
-of `libccid`. As a workaround you can try using
-`resources/linux-fix-ccid-udev`.

--- a/README
+++ b/README
@@ -87,3 +87,12 @@ prior to distribution:
   packagesbuild resources/neoman.pkgproj
   productsign --sign 'Developer ID Installer' dist/YubiKey\ NEO\ Manager.pkg dist/yubikey-neo-manager-mac.pkg
 
+
+==== Linux
+
+On Linux you can install the pyside and pycrytpo python modules provided by
+your Linux distribution and create a virtualenv with `--system-site-packages`.
+
+If you have problems running in U2F+CCID mode you might have an older version
+of `libccid`. As a workaround you can try using
+`resources/linux-fix-ccid-udev`.

--- a/doc/Usage.adoc
+++ b/doc/Usage.adoc
@@ -68,3 +68,12 @@ that if you have NEO Manager installed on multiple computers, the name
 change will only be reflected on the computer the change was made on.
 
 image:image4.PNG[image]
+
+
+=== U2F+CCID not working on Linux
+
+For Linux distributions with older libccid version, U2F+CCID mode will not
+work.
+
+Update the libccid package or use the workaround provided in the source
+code.


### PR DESCRIPTION
This is a follow up for https://github.com/Yubico/libykneomgr/issues/27

I could not find any public documentation talking about resources/linux-fix-ccid-udev

-------

I am using Ubuntu 14.04 which should still be a popular / standard Linux distro :)

It have libccid 1.4.15-1

I am using the provided PPA ... and ykneomgr did not complained about older versions of libccid... it installed just fine :)

-----

I tried to update the readme with the important part required to run this for dev on Linux

I tried to document the Linux issue and the workaround in the docs.

----------

Do you know what libccid is required for U2F+CCID

Thanks!